### PR TITLE
Don't allow hostnames with tildes

### DIFF
--- a/lib/activemodel_email_address_validator/email_address.rb
+++ b/lib/activemodel_email_address_validator/email_address.rb
@@ -32,7 +32,7 @@ module ActiveModelEmailAddressValidator
 
       user, host = *email_parts
       return false unless user =~ /^([^.]+\S)*[^. ]+$/
-      return false unless host =~ /^([^,. ]+\.)+[^,. ]+$/
+      return false unless host =~ /^([^,. ~]+\.)+[^,. ]+$/
       true
     end
   end

--- a/test/activemodel-email_address_validator/test_email_address.rb
+++ b/test/activemodel-email_address_validator/test_email_address.rb
@@ -101,6 +101,10 @@ class EmailAddressValidTest < MiniTest::Test
     reject("my@domain.com,")
   end
 
+  def test_rejects_tildes_in_hostname
+    reject("my@~domain.com")
+  end
+
   def test_handles_long_failing_strings
     reject("fernandeztorralbofrancisco@sabadellatlantico.")
   end


### PR DESCRIPTION
foo@~example.com is not valid - at least not in common cases.