### PR TITLE
Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Ability to specify custom rules to use when validating the email address
+  using the `:with` option.
+
 - Support for Ruby 2.5, 2.5 and 2.6. We've probably always had the support,
   but now we're actually testing it.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ If you want to use a specific regular expression:
 
     validates :email, :email_address => {:format => /.+@.+\..+/}
 
+### Bring your own logic
+
+If a regular expression isn't enough for you, you can include your own rules for email addresses. For example, you could validate that all email adresses belong to the same company:
+
+    validates :email, :email_address => {
+      :with => proc { |address| address.end_with?("@substancelab.com") }
+    }
+
 ### Verify domain (still to be done - pull request, anybody?)
 
 This also checks that the domain actually has an MX record. Note this might take a while because of DNS lookups.

--- a/lib/validator/email_address_validator.rb
+++ b/lib/validator/email_address_validator.rb
@@ -3,12 +3,39 @@ require "activemodel_email_address_validator/email_address"
 
 class EmailAddressValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    address = ActiveModelEmailAddressValidator::EmailAddress.new(value)
-    regex = options[:format]
-    invalidate(record, attribute) unless address.valid?(regex)
+    rules = Array(options[:with] || [])
+    if rules.any?
+      # We are using the new syntax with support for multiple validations
+      invalidate(record, attribute) unless all_rules_pass?(rules, value)
+    else
+      # We are using the old syntax, assume regular expressions
+      address = ActiveModelEmailAddressValidator::EmailAddress.new(value)
+      regex = options[:format]
+      invalidate(record, attribute) unless address.valid?(regex)
+    end
   end
 
   private
+
+  def all_rules_pass?(rules, address)
+    evaluators = rules.map { |rule| build_evaluator(rule) }
+    results = evaluators.map { |evaluator| evaluator.call(address) }
+    results.all?
+  end
+
+  # Returns an evaluator for the given rule. Evaluators are objects that respond
+  # to `#call` with an arity of 1; the raw attribute value in question.
+  #
+  # The return-value of `#call` should be `true` if the address passes the given
+  # rule, false otherwise.
+  def build_evaluator(rule)
+    case rule
+    when Regexp
+      proc { |a| a =~ rule }
+    else
+      rule
+    end
+  end
 
   def invalidate(record, attribute)
     record.errors.add(attribute, :invalid)

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,3 +6,22 @@ require "activemodel-email_address_validator"
 
 require "minitest/autorun"
 require "minitest/spec"
+
+SIMPLEST_VALIDATION = {:email => {:email_address => true}}
+
+# rubocop:disable Metrics/MethodLength
+def build_model_with_validations(validations = SIMPLEST_VALIDATION)
+  klass = Class.new do
+    include ActiveModel::Validations
+    def self.model_name
+      ActiveModel::Name.new(self, nil, "ValidatorModel")
+    end
+
+    validations.each do |attribute, options|
+      attr_accessor attribute
+      validates attribute, options
+    end
+  end
+  klass.new
+end
+# rubocop:enable Metrics/MethodLength

--- a/test/test_active_model_integration.rb
+++ b/test/test_active_model_integration.rb
@@ -1,24 +1,6 @@
 require "minitest_helper"
 require "active_model"
 
-# rubocop:disable Metrics/MethodLength
-SIMPLEST_VALIDATION = {:email => {:email_address => true}}
-def build_model_with_validations(validations = SIMPLEST_VALIDATION)
-  klass = Class.new do
-    include ActiveModel::Validations
-    def self.model_name
-      ActiveModel::Name.new(self, nil, "ValidatorModel")
-    end
-
-    validations.each do |attribute, options|
-      attr_accessor attribute
-      validates attribute, options
-    end
-  end
-  klass.new
-end
-# rubocop:enable Metrics/MethodLength
-
 class EmailAddressValidatorTest < MiniTest::Test
   def setup
     @subject = build_model_with_validations


### PR DESCRIPTION
Adds support for custom rules when validating the email address. This is primarily an opening for us to be able to extend the validator with builtin validations like Mailgun or Mailcheck or whatever we can think of.

For now it works as a fairly simple way to specify your email validation requirements outside of what a regex can give you.
