### PR TITLE
Test against support and preview versions only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - 2.7.0-preview1
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ rvm:
   - 2.6.3
   - 2.7.0-preview1
 
+before_install:
+  - gem update --system
+  - gem install bundler
+
 notifications:
   recipients:
     - jakob@mentalized.net

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for Ruby 2.5, 2.5 and 2.6. We've probably always had the support,
   but now we're actually testing it.
 
+### Removed
+
+- Support for Ruby 2.2 and 2.3 that are both EOL. We probably still support
+  and work on those versions, but we won't verify and test them any more.
+
 ## [1.0.1]
 
 ### Added

--- a/activemodel-email_address_validator.gemspec
+++ b/activemodel-email_address_validator.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activemodel", ">= 4.0", "< 6.0"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
This removes support for Ruby 2.2 and 2.3, and starts adding support for Ruby 2.7