### PR TITLE
Clarify support for UTF-8 characters in email addresses

### DIFF
--- a/test/activemodel-email_address_validator/test_email_address.rb
+++ b/test/activemodel-email_address_validator/test_email_address.rb
@@ -5,6 +5,10 @@ class EmailAddressValidTest < MiniTest::Test
     accept("bob@example.com")
   end
 
+  def test_accepts_non_us_ascii_in_local_part
+    accept("bøb@example.com")
+  end
+
   def test_rejects_email_address_without_at_sign
     reject("bobexample.com")
   end


### PR DESCRIPTION
First of all, we already validate those as valid, so this is just a codification
of that expectation.

Second of all, it is a valid email address - at least according to RFC6532
<https://tools.ietf.org/html/rfc6532>. It still needs to be encoded properly
before actually being delivered. The Mail gem added support for this in v2.7.0:
https://github.com/mikel/mail/pull/1103.

That said, actually finding services that support this is still hard (in 2019).
Neither Gmail nor Hotmail supports this for their own local accounts, but can
send to email addresses with non-US ASCII characters. Exim has added
experimental support, it seems (https://bugs.exim.org/show_bug.cgi?id=1516).

Firefox, Chrome, and Safari rejects email addresses with non-US ASCII characters
when validating email fields. Mailguns email validation API says the address is
invalid (or rather it gives `"result": "unknown", `).

Regardless of the lack of widespread support we allow these addresses because
the guiding principle is:

> Don't reject a valid email address realistically in use by a potential user.
> Err on the side of accepting too much.

An email address with non-US ASCII characters can realistically be in use by a
potential user, even though the major international players doesn't support
that.