### PR TITLE
Relax dependencies

### DIFF
--- a/activemodel-email_address_validator.gemspec
+++ b/activemodel-email_address_validator.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activemodel", ">= 4.0", "< 7.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Newer versions of both Bundler and Rake have been released, which we support
just fine, while still supporting the older versions.