### PR TITLE
Reject email addresses with trailing at signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for Ruby 3.0. We've also started testing against Ruby 3.1 to be
   prepared.
 
+- Email addresses with trailing @'s are no longer accepted. Thanks
+  @prognostikos!
+
 ### Removed
 
 -

--- a/lib/activemodel_email_address_validator/email_address.rb
+++ b/lib/activemodel_email_address_validator/email_address.rb
@@ -26,7 +26,7 @@ module ActiveModelEmailAddressValidator
 
     def valid_using_default?
       return false if /\s+/.match?(address)
-      email_parts = address.split("@")
+      email_parts = address.split("@", -1)
 
       return false unless email_parts.size == 2
 

--- a/test/activemodel-email_address_validator/test_email_address.rb
+++ b/test/activemodel-email_address_validator/test_email_address.rb
@@ -101,6 +101,14 @@ class EmailAddressValidTest < MiniTest::Test
     reject("my@nice@domain.com")
   end
 
+  def test_rejects_leading_at_signs
+    reject("@my@domain.com")
+  end
+
+  def test_rejects_trailing_at_signs
+    reject("my@domain.com@")
+  end
+
   def test_rejects_commas_in_hostname
     reject("my@domain.com,")
   end


### PR DESCRIPTION
From String#split:

> If the limit parameter is omitted, trailing null fields are suppressed.

We don't want that as that allows email addresses like `"foo@example.com@@@"`. However...

> If negative, there is no limit to the number of fields returned, and trailing null fields are not suppressed.

Which is the expected behavior.

Closes #18 