### PR TITLE
Require addresses to pass the built-in EMAIL_REGEXP

### DIFF
--- a/lib/activemodel_email_address_validator/email_address.rb
+++ b/lib/activemodel_email_address_validator/email_address.rb
@@ -34,6 +34,7 @@ module ActiveModelEmailAddressValidator
 
     def valid_using_default?
       return false if /(\s|["'<>,])+/.match?(address)
+      return false unless URI::MailTo::EMAIL_REGEXP.match?(address)
 
       email_parts = address.split("@", -1)
       return false unless email_parts.size == 2

--- a/test/activemodel-email_address_validator/test_email_address.rb
+++ b/test/activemodel-email_address_validator/test_email_address.rb
@@ -140,6 +140,10 @@ class EmailAddressValidTest < MiniTest::Test
     reject("email123@exa'mple.com")
   end
 
+  def test_rejects_unmailable_usernames
+    reject("abdalah291]79@example.com")
+  end
+
   private
 
   def accept(email_address)


### PR DESCRIPTION
We had an address pass the validation of this gem but was subsequently
treated as invalid when using the mail gem in a very odd way - the
Mail::Message#to method returned a String instead of a
Mail::AddressContainer. This commit uses the built-in
URI::MailTo::EMAIL_REGEXP as part of the default validation.

However, adding this breaks another test - allowing non-ascii characters
in the local part of the address. For us this is OK as we use Amazon SES
at the moment which also does not allow non-ascii characters, but I'm
guessing this may be a problem for others given that the test exists in
the first place.

Perhaps it should be a configuration option? Or feel free to tell us that
we'll need to do that as a separate validation in our app.
