### PR TITLE
Don't rely on ancient MiniTest compatibility layer

### DIFF
--- a/test/activemodel-email_address_validator/test_email_address.rb
+++ b/test/activemodel-email_address_validator/test_email_address.rb
@@ -1,6 +1,6 @@
 require "minitest_helper"
 
-class EmailAddressValidTest < MiniTest::Test
+class EmailAddressValidTest < Minitest::Test
   def test_accepts_common_email_address_format
     accept("bob@example.com")
   end
@@ -153,7 +153,7 @@ class EmailAddressValidTest < MiniTest::Test
   end
 end
 
-class EmailAddressTest < MiniTest::Test
+class EmailAddressTest < Minitest::Test
   def test_to_s_uses_address
     email_address = ActiveModelEmailAddressValidator::EmailAddress.new(
       "bob@example.com"

--- a/test/test_active_model_integration.rb
+++ b/test/test_active_model_integration.rb
@@ -1,7 +1,7 @@
 require "minitest_helper"
 require "active_model"
 
-class EmailAddressValidatorTest < MiniTest::Test
+class EmailAddressValidatorTest < Minitest::Test
   def setup
     @subject = build_model_with_validations
   end


### PR DESCRIPTION
The MiniTest naming layer is no longer loaded by default as per minitest 5.19.0 (https://github.com/minitest/minitest/blob/master/History.rdoc#label-5.19.0+-2F+2023-07-26)