### PR TITLE
Add support for ActiveModel 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Support for ActiveModel 8 (no changes).
 - Support for Ruby 3.3 and 3.4 (no changes).
 
 ### Removed

--- a/activemodel-email_address_validator.gemspec
+++ b/activemodel-email_address_validator.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", ">= 4.0", "< 8.0"
+  spec.add_dependency "activemodel", ">= 4.0", "< 9.0"
 
   spec.add_development_dependency "bundler", ">= 1.7"
   spec.add_development_dependency "rake", ">= 10.0"


### PR DESCRIPTION
Officially support ActiveModel 8. This is a no-op change to officially support ActiveModel 8.

Depends on #38 