### PR TITLE
Remove support for legacy Ruby version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 -
 
-## [2.2.0]
+## [3.0.0]
 
 ### Added
 
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
--
+- Support for Rubies before 3.0.
 
 ## [2.1.1]
 


### PR DESCRIPTION
Ruby versions before 3.0 are very much not maintained anymore, they are starting to fail on CI, so let's cut the ties and move on.