### PR TITLE
Remove deprecated :format option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - Support for Rubies before 3.0.
+- Passing a regular expression with :format is no longer supported. Use the
+  :with option instead.
 
 ## [2.1.1]
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,13 @@ Quite frankly, I don't care about the RFC at this point, neither does the user. 
 
     validates :email, :email_address => true
 
-### Bring your own regex
-
-If you want to use a specific regular expression:
-
-    validates :email, :email_address => {:format => /.+@.+\..+/}
-
 ### Bring your own logic
 
-If a regular expression isn't enough for you, you can include your own rules for email addresses. For example, you could validate that all email adresses belong to the same company:
+If the default behavior isn't enough for you, you can include a custom rule for email addresses. For example to match the email addresses against a regular expression:
+
+    validates :email, :email_address => {:with => /.+@.+\..+/}
+
+Or you could go beyound simple matching and validate that all email adresses belong to the same company:
 
     validates :email, :email_address => {
       :with => proc { |address| address.end_with?("@substancelab.com") }

--- a/lib/validator/email_address_validator.rb
+++ b/lib/validator/email_address_validator.rb
@@ -3,11 +3,12 @@ require "activemodel_email_address_validator/email_address"
 
 class EmailAddressValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    rules = Array(options[:with] || [])
-    if rules.empty?
-      # We are using the old syntax, assume regular expressions
-      rules = [build_rule_from_format(options[:format])]
+    if options[:format]
+      raise ArgumentError, "Don't use deprecated :format option. Use :with instead"
     end
+
+    rules = Array(options[:with] || [])
+    rules << build_default_rule if rules.empty?
 
     invalidate(record, attribute) unless all_rules_pass?(rules, value)
   end
@@ -34,11 +35,11 @@ class EmailAddressValidator < ActiveModel::EachValidator
     end
   end
 
-  def build_rule_from_format(format)
+  def build_default_rule
     proc { |attribute_value|
       address =
         ActiveModelEmailAddressValidator::EmailAddress.new(attribute_value)
-      address.valid?(format)
+      address.valid?
     }
   end
 

--- a/test/test_active_model_integration.rb
+++ b/test/test_active_model_integration.rb
@@ -31,15 +31,14 @@ class EmailAddressValidatorTest < Minitest::Test
     assert !subject.errors[:work_email].empty?
   end
 
-  def test_validates_with_custom_regular_expression
+  def test_fails_when_using_deprecated_format_option
     subject = build_model_with_validations(
       email: {email_address: {format: /.+@enterprise\..+/}}
     )
-    accept("whatever@enterprise.museum", subject)
-    reject("totally@valid.com", subject)
+    assert_raises(ArgumentError) { subject.valid? }
   end
 
-  def test_validates_with_custom_regular_as_a_rule
+  def test_validates_with_custom_regular_expression_as_a_rule
     subject = build_model_with_validations(
       email: {email_address: {with: /.+@enterprise\..+/}}
     )


### PR DESCRIPTION
If you still need to match email addresses against a custom regular expression, you can use the :with option:

    validates :email, :email_address => {:with => /.+@.+\..+/}